### PR TITLE
Update Promise support in Safari

### DIFF
--- a/data.json
+++ b/data.json
@@ -43,10 +43,9 @@
       ]
     },
     "safari": {
-      "icon": "webkit-nightly",
-      "supported": 0.5,
+      "supported": 1,
+      "minVersion": 8,
       "details": [
-        "Supported in <a href=\"http://nightly.webkit.org/\">nightlies</a> only",
         "<code>Promise.resolve(promise)</code> creates new promise instance. <a href=\"https://bugs.webkit.org/show_bug.cgi?id=128382\">Ticket</a>."
       ]
     },


### PR DESCRIPTION
Promise support is landing Safari 8 in OS X 10.10 Yosemite.
