### PR TITLE
Updated status of background sync in Chrome

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -510,11 +510,8 @@
       "name": "Background sync",
       "description": "Deferring tasks until the user has connectivity. <a href=\"https://github.com/slightlyoff/BackgroundSync\">Spec</a>. <a href=\"demos/sync/\">Test</a>.",
       "chrome": {
-        "icon": "chrome-canary",
-        "supported": 0.5,
-        "details": [
-          "Requires <a href=\"https://www.google.com/chrome/browser/canary.html\">Chrome Canary</a> and #enable-experimental-web-platform-features in chrome://flags/"
-        ]
+        "supported": 1,
+        "minVersion": 49
       },
       "firefox": {
         "supported": 0,


### PR DESCRIPTION
No longer behind a flag in Chrome 49 :fireworks: