### PR TITLE
Add resource article: Using Service Workers (MDN)

### DIFF
--- a/src/resources.html
+++ b/src/resources.html
@@ -16,6 +16,7 @@
       <li><a href="http://jakearchibald.com/2014/using-serviceworker-today/">Using Service Workers Today</a></li>
       <li><a href="https://developers.google.com/web/fundamentals/getting-started/primers/promises">JavaScript Promises: an Introduction</a></li>
       <li><a href="http://jakearchibald.com/2014/offline-cookbook/">The offline cookbook</a></li>
+      <li><a href="https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers">Using Service Workers (<abbr title="Mozilla Developer Network">MDN</abbr>)</a></li>
     </ul>
   </article>
 


### PR DESCRIPTION
The **Using Service Workers** article on MDN is a useful resource. This pull request adds it to the [**Articles** section on the **Resources** page](https://jakearchibald.github.io/isserviceworkerready/resources.html#articles).