### PR TITLE
Safari 10.1 beta supports fetch

### DIFF
--- a/src/css/_components.scss
+++ b/src/css/_components.scss
@@ -231,17 +231,17 @@
     }
 
     @media (min-width: 578px) {
-      border-radius: 600px;
-      bottom: 10%;
-      right: 10%;
+      border-radius: 4px;
+      bottom: 5%;
+      right: 5%;
       padding: 0;
       box-shadow: 0 2px 3px rgba(0, 0, 0, 0.3);
       @include display-flex;
       @include justify-content(center);
       @include align-items(center);
 
-      width: 33%;
-      height: 33%;
+      width: 50%;
+      height: 30%;
     }
   }
 

--- a/src/data.json
+++ b/src/data.json
@@ -542,10 +542,10 @@
         "minVersion": 4.0
       },
       "safari": {
-        "supported": 0.5,
-        "icon": "webkit",
+        "supported": 1,
+        "minVersion": 10.1,
         "details": [
-          "Partial support landing in <a href=\"https://nightly.webkit.org/\">WebKit nightly</a>"
+          "Support landing in <a href=\"https://developer.apple.com/library/prerelease/content/releasenotes/General/WhatsNewInSafari/Articles/Safari_10_1.html\">Safari 10.1 beta</a>"
         ]
       },
       "edge": {


### PR DESCRIPTION
The version bubble isn't ideal for `10.1+` though.

<img width="614" alt="screen shot 2017-01-24 at 14 59 40" src="https://cloud.githubusercontent.com/assets/3341/22266522/ef108b14-e245-11e6-9df9-6f8859f6b3ec.png">
