### PR TITLE
Make chevron visible on mobile chrome

### DIFF
--- a/src/css/_components.scss
+++ b/src/css/_components.scss
@@ -5,7 +5,7 @@
 }
 
 .hero {
-  height: calc(100vh - 2em);
+  height: calc(100vh - 2em - 60px);
   display: flex;
   justify-content: space-between;
   flex-direction: column;


### PR DESCRIPTION
Fix for the hiding chrome in Chrome not calculated in the vh. https://stackoverflow.com/a/46055284/26406

Before:

![screenshot_20180502-162502](https://user-images.githubusercontent.com/3341/39550251-454fba70-4e26-11e8-96a5-e81abf71ca35.png)

After:

![screenshot_20180502-162740](https://user-images.githubusercontent.com/3341/39550256-48fc172c-4e26-11e8-9f21-5abda30f4eab.png)
