### PR TITLE
Remove now that iOS supports service workers

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -61,10 +61,7 @@
         "details": [
           "<a href=\"https://blogs.windows.com/msedgedev/2018/04/30/edgehtml-17-april-2018-update/\">Shipped</a>."
         ]
-      },
-      "details": [
-        "Support does not include iOS versions of third-party browsers on that platform (see Safari support)."
-      ]
+      }
     },
     {
       "name": "Promises",


### PR DESCRIPTION
https://webkit.org/status/#specification-service-workers
https://webkit.org/blog/8090/workers-at-your-service/

Information is sparse about it but it does work now!

Test on iOS device, works offline, but doesn't show you the offline page when offline like on Chrome devices.
https://deanhume.github.io/Service-Worker-Offline/