### PR TITLE
Update support for Background Sync

### DIFF
--- a/src/data.json
+++ b/src/data.json
@@ -645,19 +645,18 @@
         ]
       },
       "opera": {
-        "supported": 0
+        "supported": 1,
+        "minVersion": 42
       },
       "samsung-internet": {
-        "supported": 0
+        "supported": 1
       },
       "safari": {
         "supported": 0
       },
       "edge": {
-        "supported": 0,
-        "details": [
-          "<a href=\"https://developer.microsoft.com/en-us/microsoft-edge/platform/status/backgroundsyncapi/\">In development</a>"
-        ]
+        "supported": 1,
+        "minVersion": 80
       }
     }
   ]


### PR DESCRIPTION
All Chromium browsers now support backgound sync.

I have manually [tested](https://jakearchibald.github.io/isserviceworkerready/demos/sync/) and confirmed the `minVersion` for Opera and Edge.
The Edge version is expected, but Opera apparently decided they weren't quite ready for such a relationship until `v42`. It's in their [changelog](https://blogs.opera.com/desktop/changelog-for-42/#:~:text=Enable%20Background%20Sync).

I have no way of testing when it was enabled in Samsung browser, but can confirm it works in 11.1.